### PR TITLE
Update release asset name and path

### DIFF
--- a/.github/workflows/update-assets-on-release.yaml
+++ b/.github/workflows/update-assets-on-release.yaml
@@ -17,14 +17,14 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: hmproto34-default
+          name: hmproto34-vial
           path: artifacts
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./artifacts/hmproto34_default.hex
-          asset_name: hmproto34_default.hex
+          asset_path: ./artifacts/hmproto34_vial.hex
+          asset_name: hmproto34_vial.hex
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the release asset name and path to reflect the changes made in the code. The previous asset name and path were "hmproto34_default.hex" and "./artifacts/hmproto34_default.hex" respectively. The new asset name and path are "hmproto34_vial.hex" and "./artifacts/hmproto34_vial.hex" respectively. This ensures that the correct release asset is uploaded when creating a new release.