### PR TITLE
Update release asset name and path

### DIFF
--- a/.github/workflows/update-assets-on-release.yaml
+++ b/.github/workflows/update-assets-on-release.yaml
@@ -17,14 +17,14 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: hmproto34-vial
+          name: hmproto34s-vial
           path: artifacts
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./artifacts/hmproto34_vial.hex
-          asset_name: hmproto34_vial.hex
+          asset_path: ./artifacts/hmproto34s_vial.hex
+          asset_name: hmproto34s_vial.hex
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the release asset name and path. The previous asset name and path were "hmproto34_vial.hex" and the new asset name and path are "hmproto34s_vial.hex". This change ensures that the correct release asset is uploaded.