### PR TITLE
Update sync-with-hmproto34.sh permissions

### DIFF
--- a/.github/workflows/sync-with-hmproto34.yaml
+++ b/.github/workflows/sync-with-hmproto34.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Sync
         run: |
+          chmod +x sync-with-hmproto34.sh
           ./sync-with-hmproto34.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the permissions of the `sync-with-hmproto34.sh` file to make it executable.