### PR TITLE
Update sync-with-hmproto34.sh to use HTTPS

### DIFF
--- a/sync-with-hmproto34.sh
+++ b/sync-with-hmproto34.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-git clone git@github.com:hmasdev/hmproto34.git ./hmproto34
+git clone https://github.com/hmasdev/hmproto34.git ./hmproto34
 cp hmproto34/keymaps/default/keymap.c ./keymaps/default/keymap.c
 cp hmproto34/keymaps/default/keymap.c ./keymaps/vial/keymap.c
 cp -r hmproto34/keymaps/hmasdevmap ./keymaps/


### PR DESCRIPTION
This pull request updates the `sync-with-hmproto34.sh` script to use HTTPS instead of SSH for cloning the `hmproto34` repository. This change ensures a more secure and reliable connection when cloning the repository.