### PR TITLE
Add compile firmware workflows

### DIFF
--- a/.github/workflows/compile-firmware-on-pull-request.yaml
+++ b/.github/workflows/compile-firmware-on-pull-request.yaml
@@ -1,0 +1,31 @@
+name: On-Pull-Request Compile
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  list-keymaps:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list-keymaps.outputs.matrix }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: List Keymaps
+        id: list-keymaps
+        run: |
+          python -c "import os,json; print('matrix='+json.dumps({'include': [{'keymap': d} for d in os.listdir('keymaps') if os.path.isdir(os.path.join('keymaps', d))]}))" >> $GITHUB_OUTPUT
+  compile:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}

--- a/.github/workflows/compile-firmware-on-push.yaml
+++ b/.github/workflows/compile-firmware-on-push.yaml
@@ -1,0 +1,32 @@
+name: On-Push Compile
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "*"
+
+jobs:
+  list-keymaps:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list-keymaps.outputs.matrix }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: List Keymaps
+        id: list-keymaps
+        run: |
+          python -c "import os,json; print('matrix='+json.dumps({'include': [{'keymap': d} for d in os.listdir('keymaps') if os.path.isdir(os.path.join('keymaps', d))]}))" >> $GITHUB_OUTPUT
+  compile:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}

--- a/.github/workflows/compile-firmware-on-schedule.yaml
+++ b/.github/workflows/compile-firmware-on-schedule.yaml
@@ -1,0 +1,31 @@
+name: Scheduled Compile
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 6"
+
+jobs:
+  list-keymaps:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list-keymaps.outputs.matrix }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: List Keymaps
+        id: list-keymaps
+        run: |
+          python -c "import os,json; print('matrix='+json.dumps({'include': [{'keymap': d} for d in os.listdir('keymaps') if os.path.isdir(os.path.join('keymaps', d))]}))" >> $GITHUB_OUTPUT
+  compile:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}


### PR DESCRIPTION
This pull request adds three new workflows: "On-Pull-Request Compile", "On-Push Compile", and "Scheduled Compile". These workflows are responsible for compiling the firmware based on different triggers such as pull request events, push events, and scheduled events. The workflows use a matrix strategy to compile the firmware for different keymaps.