### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/compile-firmware-workflow-call.yaml
+++ b/.github/workflows/compile-firmware-workflow-call.yaml
@@ -71,7 +71,7 @@ jobs:
           KEYBOARD_NAME: "hmproto34s"
           KEYMAP_NAME: ${{ inputs.keymap }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hmproto34s-${{ inputs.keymap }}
           path: ~/artifacts


### PR DESCRIPTION
This pull request updates the `upload-artifact` action to version 4. The previous version was causing issues with artifact uploads. This update ensures a smoother and more reliable artifact upload process.

#24