### PR TITLE
Refactor keymap layer order

### DIFF
--- a/keymaps/hmasdevmap/keymap.c
+++ b/keymaps/hmasdevmap/keymap.c
@@ -5,8 +5,8 @@
 
 /* layer name */
 enum keymap_layer {
-    KL_QWERTY = 0,
-    KL_NORMAN,
+    KL_NORMAN = 0,
+    KL_QWERTY,
     KL_OPE,
     KL_FUN,
     KL_SYMNUM,


### PR DESCRIPTION
This pull request refactors the keymap layer order. The KL_NORMAN layer is now set as the first layer, followed by KL_QWERTY.