### PR TITLE
Refactor keymap combos for improved functionality

### DIFF
--- a/keymaps/hmasdevmap/keymap.c
+++ b/keymaps/hmasdevmap/keymap.c
@@ -212,7 +212,7 @@ combo_t key_combos[] = {
     // for space/back-space/hyphen/period
     COMBO(KC_COMM_B, LT(KL_SYMNUM, KC_MINS)),  // qwerty
     COMBO(KC_COMM_K, LT(KL_SYMNUM, KC_MINS)),  // mod norman
-    COMBO(KC_COMM_V, KC_DOT),  // qwerty / mod norman
+    COMBO(KC_COMM_V, LT(KL_SYMNUM, KC_DOT)),  // qwerty / mod norman
     COMBO(KC_SPACE_N, KC_BSPC),  // qwerty
     COMBO(KC_SPACE_H, KC_BSPC),  // mod norman
     COMBO(KC_SPACE_M, LSFT_T(KC_SPACE)),  // qwerty / mod norman


### PR DESCRIPTION
This pull request includes a refactoring of the keymap combos to improve their functionality. Specifically, the combo for the "KC_COMM_V" key has been modified to switch to the "KL_SYMNUM" layer when pressed in combination with the "KC_DOT" key. This change enhances the usability and efficiency of the keymap.