### PR TITLE
patch: Install Python dependencies in firmware workflow

### DIFF
--- a/.github/workflows/compile-firmware-workflow-call.yaml
+++ b/.github/workflows/compile-firmware-workflow-call.yaml
@@ -49,6 +49,7 @@ jobs:
         run: |
           git clone https://github.com/vial-kb/vial-qmk.git ~/vial-qmk
           cd ~/vial-qmk
+          python -m pip install -r requirements.txt
           make git-submodule
           qmk doctor || echo 'qmk doctor failed'
       - name: Copy my keyboards into qmk_firmsware


### PR DESCRIPTION
Integrate the installation of Python dependencies into the firmware workflow to streamline the setup process.

See https://github.com/hmasdev/hmproto34s/actions/runs/11780968238