### PR TITLE
add new key combinations to hmasdevmap keymap

### DIFF
--- a/keymaps/hmasdevmap/keymap.c
+++ b/keymaps/hmasdevmap/keymap.c
@@ -147,10 +147,14 @@ const uint16_t PROGMEM KC_RT[] = {KC_R, KC_T, COMBO_END};
 const uint16_t PROGMEM KC_FB[] = {KC_F, KC_B, COMBO_END};
 const uint16_t PROGMEM KC_WER[] = {KC_W, KC_E, KC_R, COMBO_END};
 const uint16_t PROGMEM KC_WDF[] = {KC_W, KC_D, KC_F, COMBO_END};
+const uint16_t PROGMEM KC_ERT[] = {KC_E, KC_R, KC_T, COMBO_END};
+const uint16_t PROGMEM KC_DFB[] = {KC_D, KC_F, KC_B, COMBO_END};
 const uint16_t PROGMEM KC_YU[] = {KC_Y, KC_U, COMBO_END};
 const uint16_t PROGMEM KC_JU[] = {KC_J, KC_U, COMBO_END};
 const uint16_t PROGMEM KC_UIO[] = {KC_U, KC_I, KC_O, COMBO_END};
 const uint16_t PROGMEM KC_URP[] = {KC_U, KC_R, KC_P, COMBO_END};
+const uint16_t PROGMEM KC_YUI[] = {KC_Y, KC_U, KC_I, COMBO_END};
+const uint16_t PROGMEM KC_JUR[] = {KC_J, KC_U, KC_R, COMBO_END};
 
 const uint16_t PROGMEM KC_SX[] = {KC_S, KC_X, COMBO_END};
 const uint16_t PROGMEM KC_DC[] = {KC_D, KC_C, COMBO_END};
@@ -217,17 +221,19 @@ combo_t key_combos[] = {
     // COMBO(KC_ER, KC_RBRC),  // qwerty [
     COMBO(KC_DF, KC_RBRC),  // mod norman [
     // COMBO(KC_IU, KC_BSLS), // qwerty ]
-    COMBO(KC_RU, KC_BSLS), // mod norman ]
+    // COMBO(KC_RT, KC_BSLS), // qwerty ]
+    // COMBO(KC_RU, KC_BSLS), // mod norman ]
+    COMBO(KC_FB, KC_BSLS), // mod norman ]
     // COMBO(KC_IO, LSFT(KC_BSLS)), // qwerty }
     COMBO(KC_RP, LSFT(KC_BSLS)), // mod norman }
-    // COMBO(KC_RT, LSFT(KC_7)),  // qwerty '
-    COMBO(KC_FB, LSFT(KC_7)),  // mod norman '
     // COMBO(KC_WER, LSFT(KC_7)),  // qwerty '
     COMBO(KC_WDF, LSFT(KC_7)),  // mod norman '
-    // COMBO(KC_YU, LSFT(KC_2)),  // qwerty "
-    COMBO(KC_JU, LSFT(KC_2)),  // mod norman "
-    // COMBO(KC_UIO, LSFT(KC_2)),  // qwerty "
-    COMBO(KC_URP, LSFT(KC_2)),  // mod norman "
+    // COMBO(KC_UIO, LSFT(KC_7)),  // qwerty '
+    COMBO(KC_URP, LSFT(KC_7)),  // mod norman '
+    // COMBO(KC_ERT, LSFT(KC_2)),  // qwerty "
+    COMBO(KC_DFB, LSFT(KC_2)),  // mod norman "
+    // COMBO(KC_YUI, LSFT(KC_2)),  // qwerty "
+    COMBO(KC_JUR, LSFT(KC_2)),  // mod norman "
 
     // for R4 keys
     COMBO(KC_SX, KC_X),  // qwerty / mod norman


### PR DESCRIPTION
This pull request includes changes to the `keymaps/hmasdevmap/keymap.c` file, adding new key combinations and updating existing ones for the mod Norman layout. The most important changes include adding new key combinations and updating the `key_combos` array to reflect these additions.

Additions to key combinations:

* Added new key combinations `KC_ERT`, `KC_DFB`, `KC_YUI`, and `KC_JUR` to the keymap.

Updates to `key_combos` array:

* Updated the `key_combos` array to include the new key combinations and modified existing entries to improve the mod Norman layout.